### PR TITLE
update hide-production-sourcemaps

### DIFF
--- a/hide-production-sourcemaps/hide-production-sourcemaps.js
+++ b/hide-production-sourcemaps/hide-production-sourcemaps.js
@@ -1,8 +1,11 @@
 var fileInfo = WebAppInternals.staticFiles;
-Object.keys(WebAppInternals.staticFiles).forEach(function(key) {
-  if (key.indexOf(".map") === key.length - ".map".length) {
-    delete WebAppInternals.staticFiles[key];
-    return;
-  }
-  WebAppInternals.staticFiles[key].sourceMapUrl = false;
+Object.keys(WebAppInternals.staticFilesByArch).forEach(function(arch) {
+  const staticFiles = WebAppInternals.staticFilesByArch[arch];
+    Object.keys(staticFiles).forEach(function(key) {
+      if (key.endsWith(".map")) {
+        delete staticFiles[key];
+        return;
+      }
+      staticFiles[key].sourceMapUrl = false;
+  });
 });

--- a/hide-production-sourcemaps/hide-production-sourcemaps.js
+++ b/hide-production-sourcemaps/hide-production-sourcemaps.js
@@ -1,11 +1,18 @@
-var fileInfo = WebAppInternals.staticFiles;
-Object.keys(WebAppInternals.staticFilesByArch).forEach(function(arch) {
-  const staticFiles = WebAppInternals.staticFilesByArch[arch];
-    Object.keys(staticFiles).forEach(function(key) {
-      if (key.endsWith(".map")) {
-        delete staticFiles[key];
-        return;
-      }
-      staticFiles[key].sourceMapUrl = false;
+const hideSourceMaps = (staticFiles) => {
+  Object.keys(staticFiles).forEach((key) => {
+    if (key.endsWith(".map")) {
+      delete staticFiles[key];
+      return;
+    }
+    staticFiles[key].sourceMapUrl = false;
   });
-});
+}
+
+if (WebAppInternals.staticFilesByArch) {
+  Object
+    .keys(WebAppInternals.staticFilesByArch)
+    .forEach((arch) => hideSourceMaps(WebAppInternals.staticFilesByArch[arch]));
+}
+if (WebAppInternals.staticFiles) {
+  hideSourceMaps(WebAppInternals.staticFiles);
+}


### PR DESCRIPTION
Update hide-production-sourcemaps to handle the differential bundle from Meteor 1.7