### PR TITLE
Fix missing lines (null) in sourcesContent

### DIFF
--- a/minifier-js-source-maps/plugin/minify-js.js
+++ b/minifier-js-source-maps/plugin/minify-js.js
@@ -24,6 +24,7 @@ meteorJsMinify = function (source, sourcemap, path) {
       // And fix terser issue #117: https://github.com/terser-js/terser/issues/117
       safari10: true,
       sourceMap: {
+        includeSources: true,
         content: sourcemap
       }
     });


### PR DESCRIPTION
At some point the sourcemaps started to miss lines for all top-level files in the packages folder, which leads to incomplete stacktraces with missing lines.

This PR forces terser to include sources, which in turn makes them show up again.

Fixes #25.