### PR TITLE
Add compatibility with Meteor 3.0 to `hide-production-sourcemaps` package

### DIFF
--- a/hide-production-sourcemaps/package.js
+++ b/hide-production-sourcemaps/package.js
@@ -12,7 +12,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use('webapp@1.3.14');
+  api.use('webapp@1.3.14 || 2.0.0');
   api.addFiles('hide-production-sourcemaps.js', 'server');
 });
 


### PR DESCRIPTION
Meteor 3.0 uses `webapp@2.0.0`, so to make `hide-production-sourcemaps` package compatibly with Meteor 3.0 we need to bump supported `webapp` package version. There were no changes in `WebAppInternals.staticFilesByArch` API in Meteor 3.0 ([ref](https://github.com/meteor/meteor/blob/c4cd4d523827677aa212c19cc6eb13fcf3a296e4/packages/webapp/webapp_server.js#L819)), so it's ok to bump `webapp` version to `2.0.0`